### PR TITLE
Replacement of deprecated library

### DIFF
--- a/template/build/utils.js
+++ b/template/build/utils.js
@@ -1,6 +1,6 @@
 var path = require('path')
 var config = require('../config')
-var ExtractTextPlugin = require('extract-text-webpack-plugin')
+var MiniCSSExtractPlugin = require('mini-css-extract-plugin')
 
 exports.assetsPath = function (_path) {
   var assetsSubDirectory = process.env.NODE_ENV === 'production'
@@ -10,49 +10,44 @@ exports.assetsPath = function (_path) {
 }
 
 exports.cssLoaders = function (options) {
-  options = options || {}
-
-  var cssLoader = {
-    loader: 'css-loader',
-    options: {
-      minimize: process.env.NODE_ENV === 'production',
-      sourceMap: options.sourceMap
-    }
-  }
-
   // generate loader string to be used with extract text plugin
-  function generateLoaders (loader, loaderOptions) {
-    var loaders = [cssLoader]
-    if (loader) {
-      loaders.push({
-        loader: loader + '-loader',
-        options: Object.assign({}, loaderOptions, {
-          sourceMap: options.sourceMap
-        })
+  function generateLoaders (loaders, loaderOptions) {
+    var styleLoader = []
+    // If typeof "loaders" is object and also is an array
+    if (typeof loaders === 'object' && Array.isArray(loaders)) {
+      loaders.forEach(function(element) {
+        if (typeof element === 'object' && !Array.isArray(element)) {
+          styleLoader.push({
+            loader: element.loader,
+            options: Object.assign({}, element.options) || {}
+          })
+        } else if (typeof element === 'string') {
+          styleLoader.push(element)
+        }
+      });
+    // If typeof "loaders" is object and is not an array 
+    } else if (typeof loaders === 'object' && !Array.isArray(loaders)) {
+      styleLoader.push({
+        loader: loaders.loader,
+        options: Object.assign({}, loaders.options) || {}
       })
+    // If typeof "loaders" is string
+    } else if (typeof loaders === 'string') {
+      styleLoader.push(loaders)
     }
-
-    // Extract CSS when that option is specified
-    // (which is the case during production build)
-    if (options.extract) {
-      return ExtractTextPlugin.extract({
-        use: loaders,
-        fallback: 'vue-style-loader'
-      })
-    } else {
-      return ['vue-style-loader'].concat(loaders)
-    }
+    return styleLoader
   }
 
   // https://vue-loader.vuejs.org/en/configurations/extract-css.html
-  return {
-    css: generateLoaders(),
-    postcss: generateLoaders(),
-    less: generateLoaders('less'),
-    sass: generateLoaders('sass', { indentedSyntax: true }),
-    scss: generateLoaders('sass'),
-    stylus: generateLoaders('stylus'),
-    styl: generateLoaders('stylus')
+
+   return {
+    css: generateLoaders([(process.env.NODE_ENV !== 'production' ? 'vue-style-loader' : MiniCSSExtractPlugin.loader), 'css-loader']),
+    postcss: generateLoaders(['vue-style-loader', { loader: 'css-loader', options: { importLoaders: 1 } }, 'postcss-loader']),
+    less: generateLoaders(['vue-style-loader', 'css-loader', 'less-loader']),
+    sass: generateLoaders(['vue-style-loader','css-loader', { loader: 'sass-loader', options: { indentedSyntax: true } }]),
+    scss: generateLoaders(['vue-style-loader','css-loader', { loader: 'sass-loader', options: { indentedSyntax: true } }]),
+    stylus: generateLoaders(['vue-style-loader', 'css-loader', 'stylus-loader']),
+    styl: generateLoaders(['vue-style-loader', 'css-loader', 'stylus-loader'])
   }
 }
 

--- a/template/build/webpack.prod.conf.js
+++ b/template/build/webpack.prod.conf.js
@@ -7,11 +7,12 @@ var merge = require('webpack-merge')
 var baseWebpackConfig = require('./webpack.base.conf')
 var CopyWebpackPlugin = require('copy-webpack-plugin')
 var HtmlWebpackPlugin = require('html-webpack-plugin')
-var ExtractTextPlugin = require('extract-text-webpack-plugin')
+var MiniCSSExtractPlugin = require('mini-css-extract-plugin')
 var OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
 var SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin')
 var loadMinified = require('./load-minified')
 var UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+var safeParser = require('postcss-safe-parser')
 
 var env = {{#if_or unit e2e}}process.env.NODE_ENV === 'testing'
   ? require('../config/test.env')
@@ -52,14 +53,15 @@ var webpackConfig = merge(baseWebpackConfig, {
     new webpack.DefinePlugin({
       'process.env': env
     }),
-    // extract css into its own file
-    new ExtractTextPlugin({
-      filename: utils.assetsPath('css/[name].[md5:contenthash:hex:15].css')
+    // mini css extract plugin
+    new MiniCSSExtractPlugin({
+      filename: 'common.[chunkhash].css'
     }),
     // Compress extracted CSS. We are using this plugin so that possible
     // duplicated CSS from different components can be deduped.
     new OptimizeCSSPlugin({
       cssProcessorOptions: {
+        parser: safeParser,
         safe: true
       }
     }),

--- a/template/package.json
+++ b/template/package.json
@@ -28,6 +28,8 @@
     "vue-cordova": "^0.1.2",
     "vue-head": "^2.0.12",
     "cordova-plugin-device": "^2.0.2",
+    "mini-css-extract-plugin": "^0.4.1",
+    "postcss-safe-parser": "^4.0.1",
     {{#lint}}
     {{#if_eq lintConfig "standard"}}
     "eslint-plugin-import": "^2.12.0",


### PR DESCRIPTION
On May 22, I reported an issue when patching '**build/utils.js**', and '**build/webpack.prod.conf.js**' to replace '**extract-text-webpack-plugin**' for '**mini-css-extract-plugin**' after  upgrading to **Webpack 4.8.3** and **vue-loader 15.2.0**. This patch was necessary in order to replace the deprecated plugin "extract-text" on Webpack 4, and add the "mini css" plugin, which was meant to replace extract-text plugin and provide compatibility with Webpack >= 4.

The patch failed. When trying to build for production, it produced the following error:

> ERROR in ./node_modules/vuetify/dist/vuetify.css
>     Module build failed: ModuleBuildError: Module build failed: ModuleParseError: Module parse failed: Unexpected character '@' (1:0)
>     You may need an appropriate loader to handle this file type.
>     | @-webkit-keyframes shake {
>     | 59% {
>     | margin-left: 0;
>     ...
>     @ ./src/main.js 5:0-34
>     @ multi babel-polyfill ./src/main.js
> 
>     ERROR in chunk app [entry]
> 

While testing the new library, I noticed that module "mini-css-extract-plugin" was not working as expected with vue-loader version 15.2.0; so the issue was directly related to vue-loader (15.2.0)

Searching through the Internet, I found a beta version for module "extract-text-webpack-plugin" (version 4.0.0-beta.0); which was designed to provide compatibility with Webpack 4. I then patched again all files mentioned above with the beta version of module "extract-text-webpack-plugin", and all errors were corrected.

Now, a few months later, I could successfully replace the deprecated module "extract-text-webpack-plugin". After patching the files, executing 'npm run dev' or 'npm run build' works as expected.

This pull request will remove deprecated modules from the template, providing compatibility with newer versions of Webpack and Vue-loader.